### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ai-refactory.yml
+++ b/.github/workflows/ai-refactory.yml
@@ -1,4 +1,6 @@
 name: Daily AI Refactor
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/andrey-usa/DataCompare/security/code-scanning/6](https://github.com/andrey-usa/DataCompare/security/code-scanning/6)

To fix the problem, add a `permissions` key at the appropriate level in the workflow file. Because all steps currently in use require only the ability to download repository contents (not write), the least privilege permission is `contents: read`. There are no custom roles, so the minimal permissions block should be set at either the root of the workflow file (applies to all jobs) or under the specific job. In this case, setting at the workflow root (just after `name:` and before `on:`) is preferable for clarity and consistency.  
**Implementation steps:**  
- Insert a `permissions:` block immediately after the `name:` line.
- Add `contents: read` under this block (with correct YAML indentation).
No imports or function modifications are required—just a YAML block addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
